### PR TITLE
adds a git reset --hard to repository reset command

### DIFF
--- a/salt/api-dummy/init.sls
+++ b/salt/api-dummy/init.sls
@@ -3,7 +3,7 @@ api-dummy-repository-reset:
     # stderr: fatal: could not set upstream of HEAD to origin/master when it does not point to any branch.
     cmd.run:
         # 'git clean -d -f' will force delete untracked directories
-        - name: cd /srv/api-dummy && git clean -d -f && git checkout master
+        - name: cd /srv/api-dummy && git reset --hard && git clean -d -f && git checkout master
         - runas: {{ pillar.elife.deploy_user.username }}
         - onlyif:
             - test -d /srv/api-dummy


### PR DESCRIPTION
seeing this:

```
14:36:57  [54.163.38.113] out:     [0;31m      ID: api-dummy-repository-reset[0;0m
14:36:57  [54.163.38.113] out:     [0;31mFunction: cmd.run[0;0m
14:36:57  [54.163.38.113] out:     [0;31m    Name: cd /srv/api-dummy && git clean -d -f && git checkout master[0;0m
14:36:57  [54.163.38.113] out:     [0;31m  Result: False[0;0m
14:36:57  [54.163.38.113] out:     [0;31m Comment: Command "cd /srv/api-dummy && git clean -d -f && git checkout master" run[0;0m
14:36:57  [54.163.38.113] out:     [0;31m Started: 04:06:04.089134[0;0m
14:36:57  [54.163.38.113] out:     [0;31mDuration: 280.05 ms[0;0m
14:36:57  [54.163.38.113] out: [0;31m     Changes:   
14:36:57  [54.163.38.113] out:               [0;36m----------[0;0m
14:36:57  [54.163.38.113] out:               [0;36mpid[0;0m:
14:36:57  [54.163.38.113] out:                   [0;1;33m4600[0;0m
14:36:57  [54.163.38.113] out:               [0;36mretcode[0;0m:
14:36:57  [54.163.38.113] out:                   [0;1;33m128[0;0m
14:36:57  [54.163.38.113] out:               [0;36mstderr[0;0m:
14:36:57  [54.163.38.113] out:                   [0;32merror: unable to write file data/articles/15691.json[0;0m
14:36:57  [54.163.38.113] out:                   [0;32merror: unable to write file data/articles/36258.json[0;0m
14:36:57  [54.163.38.113] out:                   [0;32merror: unable to write file data/articles/40684.json[0;0m
14:36:57  [54.163.38.113] out:                   [0;32merror: unable to write file data/articles/53433.json[0;0m
14:36:57  [54.163.38.113] out:                   [0;32merror: unable to write file data/articles/55774.json[0;0m
14:36:57  [54.163.38.113] out:                   [0;32merror: unable to write file data/recommendations/article-45562.json[0;0m
14:36:57  [54.163.38.113] out:                   [0;32merror: unable to write file src/bootstrap.php[0;0m
14:36:57  [54.163.38.113] out:                   [0;32merror: unable to write file test/SmokeTest.php[0;0m
14:36:57  [54.163.38.113] out:                   [0;32mfatal: unable to write new index file[0;0m
```

which is strange. I'm guess they are locked or something ...